### PR TITLE
Create new resource aws_s3_bucket_acl

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,12 @@ resource "aws_s3_bucket" "flow_logs" {
   count = var.is_enabled ? 1: 0
 
   bucket_prefix = "cloud-platform-"
+}
+
+resource "aws_s3_bucket_acl" "flow_logs_bucket_acl" {
+  count = var.is_enabled ? 1: 0
+  
+  bucket = aws_s3_bucket.flow_logs[count.index].id
   acl    = "private"
 }
 


### PR DESCRIPTION
As acl is not supported in aws_s3_bucket, with the new aws provider upgrade.

Warning: Argument is deprecated
Use the aws_s3_bucket_acl resource instead
