### PR TITLE
✨ output flowlogs s3 bucket arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Some of the inputs are tags. All infrastructure resources need to be tagged acco
 
 | Name | Description |
 |------|-------------|
-| s3_bucket_name | S3 bucket containing the flow_logs|
+| s3_bucket_arn | S3 bucket arn containing the flow_logs|
 
 ## Reading Material
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "s3_bucket_arn" {
+  description = "s3 bucket arn"
+  value = aws_s3_bucket.flow_logs[0].arn
+}


### PR DESCRIPTION
This PR will output the S3 Bucket ARN value of where the VPC FlowLogs are going to.

Will call this value in the VPC infra terraform outputs, and in turn use this value to configure SQS event permissions on the bucket. This relates to the issue [Push Production VPC flow logs to Cortex](https://github.com/ministryofjustice/cloud-platform/issues/5609)

