### PR TITLE
🔧add condition to output s3 bucket arn only if enabled

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "s3_bucket_arn" {
   description = "s3 bucket arn"
-  value = length(aws_s3_bucket.flow_logs) > 0 ? aws_s3_bucket.flow_logs[0].arn : null
+  value = var.is_enabled ? aws_s3_bucket.flow_logs[0].arn : null
 }


### PR DESCRIPTION
Relates to [Push Production VPC flow logs to Cortex](https://github.com/ministryofjustice/cloud-platform/issues/5609)