### PR TITLE
🔧 additional VPC flow log fields required for Cortex XSIAM

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "aws_flow_log" "vpc_log" {
   log_destination = aws_s3_bucket.flow_logs[count.index].arn
   traffic_type    = var.traffic_type
   vpc_id          = var.vpc_id
+  log_format      = var.log_format
 }
 
 resource "aws_flow_log" "subnet_log" {

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,8 @@ variable "is_enabled" {
   description = "switch to enable/disable the module, defaults to false"
   default = false
 }
+
+variable "log_format" {
+  description = "Fields to include in the flow log record"
+  default = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${az-id} $${flow-direction} $${instance-id} $${pkt-srcaddr} $${pkt-dstaddr} $${region} $${sublocation-id} $${sublocation-type} $${subnet-id} $${tcp-flags} $${type} $${vpc-id}"
+}


### PR DESCRIPTION
This PR adds additional fields to the VPC flow logs records.

Currently the flow logs are set have the default `log_format` with the following fields:
```
${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}
``` 

This PR will set a custom `log_format`, which essentially is just appending additional fields to the flow logs and will now have the following fields:
```
${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status} ${az-id} ${flow-direction} ${instance-id} ${pkt-srcaddr} ${pkt-dstaddr} ${region} ${sublocation-id} ${sublocation-type} ${subnet-id} ${tcp-flags} ${ype} ${vpc-id}
```

The requirement for this is explained in issue [XSIAM: VPC Flow log custom filters](https://github.com/ministryofjustice/cloud-platform/issues/6169)